### PR TITLE
Add sandbox local build and push script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL: build
 
-.REGISTRY	= hmcts.azurecr.io
+.REGISTRY = hmcts.azurecr.io
+.SANDBOX_REGISTRY = hmctssandbox.azurecr.io
 .NAMESPACES	= hmcts/base/node
 
 .REFS =	alpine-lts-8►8/alpine \
@@ -21,10 +22,29 @@ define run-test
 
 endef
 
-build:
+define push-sandbox
+	docker tag \
+		$(.REGISTRY)/$(.NAMESPACES)/$(word 1,$(subst ►, ,$(1))) \
+		$(.SANDBOX_REGISTRY)/$(.NAMESPACES)/$(word 1,$(subst ►, ,$(1)))
+	docker push $(.SANDBOX_REGISTRY)/$(.NAMESPACES)/$(word 1,$(subst ►, ,$(1)))
+
+endef
+
+help:
+	@echo ""
+	@echo " Available commands:"
+	@echo " -------------------"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf " make \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+
+build: ## Build locally the base images.
 	$(foreach ref,$(.REFS),$(call run-docker,$(ref)))
 
-test:
+test: ## Test basic properties of the images, e.g. user, workdir, default command.
 	$(foreach tag,$(.TAGS),$(call run-test,$(tag)))
 
-.PHONY: build test
+sandbox: ## Tag the images and pushes them to hmctssandbox.azurecr.io sandbox ACR (make sure you are logged in).
+	$(foreach ref,$(.REFS),$(call push-sandbox,$(ref)))
+
+.PHONY: build test sandbox help

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ $ make
 
 This will generate the right tags so that you can use those images to build other nodejs-based projects open-sourced by HMCTS.
 
+## Building images for sandbox
+
+Sandbox is as its named, a _sandbox_ registry. Thus, the base images are not automatically pushed in the sandbox registry `hmctssandbox`.
+
+However you can though still push them from your workstation using the `make sandbox` command.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/hmcts/ccd-definition-designer-api/blob/master/LICENSE.md) file for details.


### PR DESCRIPTION
Convenience script allowing a manual release of the base images on the `hmctssandbox` registry.